### PR TITLE
Add shared USE_XLA config and cleanup

### DIFF
--- a/common.py
+++ b/common.py
@@ -1,0 +1,4 @@
+import tensorflow as tf
+
+# Enable XLA JIT compilation when a GPU is available
+USE_XLA = bool(tf.config.list_physical_devices('GPU'))

--- a/volatility/discrete.py
+++ b/volatility/discrete.py
@@ -3,7 +3,7 @@ from pricers.black_utils import bs_price
 import tensorflow as tf
 tf.keras.backend.set_floatx('float64')
 
-USE_XLA = bool(tf.config.list_physical_devices('GPU'))
+from common import USE_XLA
 class ImpliedVolSurface:
     def __init__(self, strikes, maturities, implied_vol_surface, t0=None, dtype=tf.float64):
         self.strikes    = tf.convert_to_tensor(strikes,             dtype=dtype)


### PR DESCRIPTION
## Summary
- add a `common` module with shared `USE_XLA` flag
- apply `USE_XLA` across volatility and pricer modules
- remove duplicate code and adjust antithetic checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`