### PR TITLE
Enable optional scan simulation for MC pricer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # ml-greeks-pricers
+
+This repo provides TensorFlow-based pricers for options, including a Monte Carlo European pricer.
+
+## MCEuropeanOption
+- Supports flat and local volatility models.
+- Default path generation uses `tf.foldl`.
+- Set `use_scan=True` to use `tf.scan` instead.


### PR DESCRIPTION
## Summary
- document project in README
- add optional `use_scan` parameter to `MCEuropeanOption`
- allow `tf.scan` when simulating local-vol paths

## Testing
- `python -m compileall -q pricers volatility common`