### PR TITLE
Add utility functions for pickling variables

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,3 +1,5 @@
 from .constants import USE_XLA
+from .utils import save_variables, load_variables
+from .random_cache import mc_noise
 
-__all__ = ["USE_XLA"]
+__all__ = ["USE_XLA", "save_variables", "load_variables", "mc_noise"]

--- a/common/random_cache.py
+++ b/common/random_cache.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import tensorflow as tf
+from typing import Dict, Tuple
+
+# Cache for stateless random normals. Keys are (shape_tuple, seed, dtype_name)
+_RANDOM_CACHE: Dict[Tuple[Tuple[int, ...], int, str], tf.Tensor] = {}
+
+
+def cached_normal(shape: tuple[int, ...], seed: int, dtype: tf.dtypes.DType = tf.float64) -> tf.Tensor:
+    """Return a cached tensor of stateless normal samples."""
+    key = (tuple(shape), int(seed), tf.as_dtype(dtype).name)
+    tensor = _RANDOM_CACHE.get(key)
+    if tensor is None:
+        tensor = tf.random.stateless_normal(shape, [seed, 0], dtype=dtype)
+        _RANDOM_CACHE[key] = tensor
+    return tensor
+
+
+def mc_noise(
+    n_steps: int,
+    n_paths: int,
+    seed: int,
+    *,
+    antithetic: bool = False,
+    dtype: tf.dtypes.DType = tf.float64,
+) -> tf.Tensor:
+    """Return cached random normals for Monte Carlo simulations."""
+    base_n = n_paths // 2 if antithetic else n_paths
+    if n_steps > 1:
+        base_shape = (n_steps, base_n)
+        noise = cached_normal(base_shape, seed, dtype)
+        if antithetic:
+            noise = tf.concat([noise, -noise], axis=1)
+    else:
+        base_shape = (base_n,)
+        noise = cached_normal(base_shape, seed, dtype)
+        if antithetic:
+            noise = tf.concat([noise, -noise], axis=0)
+    return noise

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+import pickle
+from typing import Any
+
+
+def save_variables(path: str | Path, **variables: Any) -> None:
+    """Save the given variables dictionary to a pickle file.
+
+    Parameters
+    ----------
+    path: str or Path
+        Destination file path. Parent directories are created if needed.
+    **variables: Any
+        Variables to serialize. They will be stored under their given names.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("wb") as fh:
+        pickle.dump(variables, fh)
+
+
+def load_variables(path: str | Path, *names: str) -> Any:
+    """Load variables from a pickle file.
+
+    Parameters
+    ----------
+    path: str or Path
+        Path to the pickle file.
+    *names: str
+        Optional names of variables to return. If omitted the entire
+        dictionary is returned.
+    """
+    p = Path(path)
+    with p.open("rb") as fh:
+        data = pickle.load(fh)
+
+    if names:
+        return tuple(data[name] for name in names)
+    return data


### PR DESCRIPTION
## Summary
- add `utils` module under `common` package with functions to save/load pickle files
- expose `save_variables` and `load_variables` in `common.__init__`

## Testing
- `pytest -q`
