### PR TITLE
Fix XLA usage and bilinear interpolation

### DIFF
--- a/pricers/european.py
+++ b/pricers/european.py
@@ -196,7 +196,7 @@ class MCEuropeanOption:
         Z = mc_noise(M, N, self.seed, antithetic=self.antithetic, dtype=self.dtype)
         return Z * sd
 
-    @tf.function(jit_compile=False)
+    @tf.function(jit_compile=USE_XLA)
     def _compute_price_and_grads(self):
         with tf.GradientTape(persistent=True) as tape:
             tape.watch(self.S0)


### PR DESCRIPTION
## Summary
- rework `bilinear` interpolation for XLA
- enable XLA for price/greeks computation when GPU is available

## Testing
- `pytest -q`