### PR TITLE
Add reusable asset simulation horizon

### DIFF
--- a/examples/european.py
+++ b/examples/european.py
@@ -8,8 +8,13 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'   # suprime avisos de backend C++
 tf.get_logger().setLevel('ERROR')          # suprime avisos Python de TF
 
 
-from ml_greeks_pricers.pricers.european import AnalyticalEuropeanOption, MCEuropeanOption
-from ml_greeks_pricers.volatility.discrete import ImpliedVolSurface, DupireLocalVol
+from ml_greeks_pricers.pricers.european import (
+    AnalyticalEuropeanOption,
+    MCEuropeanOption,
+    EuropeanAsset,
+    MarketData,
+)
+from ml_greeks_pricers.volatility.discrete import DupireLocalVol
 
 
 if __name__ == '__main__':
@@ -21,7 +26,17 @@ if __name__ == '__main__':
     analytical_price = analEur().numpy()
     tf.print('analytical', analytical_price, analEur.delta(), analEur.vega())
     # ---- volatilidad constante ---------------------------------------
-    mc_flat = MCEuropeanOption(S0,K,T,r,q,iv_vol, n_paths=n_paths, n_steps=n_steps, use_scan=True, seed=0)
+    market_flat = MarketData(r, iv_vol)
+    asset_flat = EuropeanAsset(
+        S0,
+        q,
+        T,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        use_scan=True,
+        seed=0,
+    )
+    mc_flat = MCEuropeanOption(asset_flat, market_flat, K, T, is_call=False)
     flat_price = mc_flat().numpy()
     tf.print('flat', flat_price, mc_flat.delta(), mc_flat.vega())
 
@@ -41,8 +56,17 @@ if __name__ == '__main__':
         [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],  # 2.00
     ]
     dup = DupireLocalVol(strikes, mats, iv, S0, r, q)
-
-    mc_loc = MCEuropeanOption(S0,K,T,r,q,dup,n_paths=n_paths, n_steps=n_steps, use_scan=True, seed=0)
+    market_dup = MarketData(r, dup)
+    asset_dup = EuropeanAsset(
+        S0,
+        q,
+        T,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        use_scan=True,
+        seed=0,
+    )
+    mc_loc = MCEuropeanOption(asset_dup, market_dup, K, T, is_call=False)
     dupire_price = mc_loc().numpy()
     tf.print('dupire', dupire_price, mc_loc.delta(), mc_loc.vega())
 

--- a/ml_greeks_pricers/pricers/european.py
+++ b/ml_greeks_pricers/pricers/european.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 tf.keras.backend.set_floatx('float64')
+import warnings
 
 from ml_greeks_pricers.volatility.discrete import ImpliedVolSurface, DupireLocalVol
 from ml_greeks_pricers.common.constants import USE_XLA
@@ -126,118 +127,172 @@ def _assert_even(n, name):
         message=f"{name} must be even when antithetic sampling is active",
     )
 
-class MCEuropeanOption:
-    """
-    Monte Carlo pricer for European options computing price, Delta and Vega at
-    the same time.
-    - ``vol_model`` float/int → flat volatility (single-step closed form)
-    - ``vol_model`` :class:`DupireLocalVol` → local volatility (Euler scheme for
-      ``S_T`` only)
-    - ``use_scan`` use ``tf.scan`` instead of ``tf.foldl`` when simulating paths
-      under local volatility
-    """
-    def __init__(self, S0, K, T, r, q, vol_model, *,
-                 is_call=False, n_paths=100_000, n_steps=60,
-                 antithetic=True, seed=0, dtype=tf.float64,
-                 use_scan=False):
-        if antithetic:
-            _assert_even(n_paths, 'n_paths')
-            _assert_even(n_steps, 'n_steps')
+class MarketData:
+    """Container for market information used in simulations."""
 
-        self.S0 = tf.constant(S0, dtype=dtype)
-        self.K  = tf.constant(K,  dtype=dtype)
-        self.T  = tf.constant(T,  dtype=dtype)
-        self.r  = tf.constant(r,  dtype=dtype)
-        self.q  = tf.constant(q,  dtype=dtype)
+    def __init__(self, r, vol_model, *, dtype=tf.float64):
+        self.r = tf.constant(r, dtype=dtype)
+        self.dtype = dtype
 
-        self.is_call    = is_call
-        self.n_paths    = n_paths
-        self.n_steps    = n_steps
-        self.antithetic = antithetic
-        self.seed       = seed
-        self.dtype      = dtype
-        self.use_scan   = use_scan
-
-        self._flat_sigma  = None
+        self._flat_sigma = None
         self._dupire_grid = None
-        self._sigma_fn    = self._build_sigma_fn(vol_model)
-
-        self._last_price = None
-        self._last_delta = None
-        self._last_vega  = None
+        self._sigma_fn = self._build_sigma_fn(vol_model)
 
     def _build_sigma_fn(self, vm):
         if isinstance(vm, (float, int)):
             self._flat_sigma = tf.Variable(float(vm), dtype=self.dtype, trainable=True)
+
             @tf.function(reduce_retracing=True)
             def const_sigma(x):
                 return tf.fill([tf.shape(x)[0]], self._flat_sigma)
+
             return const_sigma
 
-        if hasattr(vm, 'surface') and hasattr(vm, 'strikes'):
+        if hasattr(vm, "surface") and hasattr(vm, "strikes"):
             self._dupire_grid = tf.Variable(vm.surface, dtype=self.dtype, trainable=True)
             strikes, mats = vm.strikes, vm.maturities
+
             @tf.function(reduce_retracing=True)
             def local_sigma(x):
-                t, spot = x[:,0], x[:,1]
+                t, spot = x[:, 0], x[:, 1]
                 grid = self._dupire_grid.read_value()
                 return ImpliedVolSurface.bilinear(t, spot, grid, strikes, mats)
+
             return local_sigma
 
         raise TypeError("vol_model must be float/int or DupireLocalVol")
 
+    def discount_factor(self, T):
+        T = tf.cast(T, self.dtype)
+        return tf.exp(-self.r * T)
+
+    def sigma(self, t, spot):
+        return self._sigma_fn(tf.stack([t, spot], axis=1))
+
+
+class EuropeanAsset:
+    """Simulates the underlying asset paths."""
+
+    def __init__(
+        self,
+        S0,
+        q,
+        T,
+        *,
+        n_paths=100_000,
+        n_steps=60,
+        antithetic=True,
+        seed=0,
+        dtype=tf.float64,
+        use_scan=False,
+    ):
+        if antithetic:
+            _assert_even(n_paths, "n_paths")
+            _assert_even(n_steps, "n_steps")
+
+        self.S0 = tf.constant(S0, dtype=dtype)
+        self.q = tf.constant(q, dtype=dtype)
+        self.T = tf.constant(T, dtype=dtype)
+        self.n_paths = n_paths
+        self.n_steps = n_steps
+        self.antithetic = antithetic
+        self.seed = seed
+        self.dtype = dtype
+        self.use_scan = use_scan
+
+        self.dt = self.T / tf.cast(self.n_steps, dtype)
+
     @tf.function(jit_compile=True, reduce_retracing=True)
     def _brownian(self):
-        M, N = self.n_steps, self.n_paths
-        dt  = self.T / tf.cast(M, self.dtype)
-        sd  = tf.sqrt(dt)
-        Z = tf.random.stateless_normal([M, N//(2 if self.antithetic else 1)],
-                                       [self.seed, 0], dtype=self.dtype)
+        dt = self.dt
+        M = self.n_steps
+        sd = tf.sqrt(dt)
+        Z = tf.random.stateless_normal(
+            [M, self.n_paths // (2 if self.antithetic else 1)],
+            [self.seed, 0],
+            dtype=self.dtype,
+        )
         if self.antithetic:
             Z = tf.concat([Z, -Z], axis=1)
         return Z * sd
 
+    def simulate(self, T, market: MarketData):
+        """Return the asset price at (possibly rounded) maturity ``T``."""
+        T = tf.cast(T, self.dtype)
+        tf.debugging.assert_less_equal(T, self.T, message="T beyond simulation horizon")
+
+        step_float = T / self.dt
+        step = tf.cast(tf.floor(step_float), tf.int32)
+        T_eff = self.dt * tf.cast(step, self.dtype)
+
+        if step_float != tf.cast(step, self.dtype):
+            warnings.warn(
+                "T not on grid; using previous discretization step",
+                RuntimeWarning,
+            )
+
+        if market._flat_sigma is not None:
+            sigma = market._flat_sigma
+            Z = tf.random.stateless_normal([self.n_paths], [self.seed, 0], dtype=self.dtype)
+            return self.S0 * tf.exp(
+                (market.r - self.q - 0.5 * sigma ** 2) * T_eff
+                + sigma * tf.sqrt(T_eff) * Z
+            )
+
+        dW = self._brownian()
+        times = tf.range(self.n_steps, dtype=self.dtype) * self.dt
+        S0 = tf.fill([self.n_paths], self.S0)
+
+        def step_fn(prev, elems):
+            dWi, tc = elems
+            sig = market._sigma_fn(
+                tf.stack([tf.fill([self.n_paths], tc), prev], axis=1)
+            )
+            return prev * tf.exp(
+                (market.r - self.q - 0.5 * sig ** 2) * self.dt + sig * dWi
+            )
+
+        if self.use_scan:
+            path = tf.scan(step_fn, (dW, times), initializer=S0)
+        else:
+            path = tf.foldl(step_fn, (dW, times), initializer=S0)
+
+        idx = tf.maximum(step - 1, 0)
+        ST = tf.where(step > 0, tf.gather(path, idx), S0)
+        return ST
+
+class MCEuropeanOption:
+    """Monte Carlo pricer for European options."""
+
+    def __init__(self, asset: EuropeanAsset, market: MarketData, K, T, *, is_call=False):
+        self.asset = asset
+        self.market = market
+        self.K = tf.constant(K, dtype=asset.dtype)
+        self.T = tf.constant(T, dtype=asset.dtype)
+        self.is_call = is_call
+
+        self._last_price = None
+        self._last_delta = None
+        self._last_vega = None
+
     @tf.function(jit_compile=True, reduce_retracing=True)
     def _compute_price_and_grads(self):
         with tf.GradientTape(persistent=True) as tape:
-            tape.watch(self.S0)
-            if self._flat_sigma is not None:
-                tape.watch(self._flat_sigma)
-            elif self._dupire_grid is not None:
-                tape.watch(self._dupire_grid)
+            tape.watch(self.asset.S0)
+            if self.market._flat_sigma is not None:
+                tape.watch(self.market._flat_sigma)
+            elif self.market._dupire_grid is not None:
+                tape.watch(self.market._dupire_grid)
 
-            # simulate the paths and compute the payoff
-            if self._flat_sigma is not None:
-                sigma = self._flat_sigma
-                Z = tf.random.stateless_normal([self.n_paths], [self.seed, 0], dtype=self.dtype)
-                ST = self.S0 * tf.exp((self.r - 0.5 * sigma**2) * self.T + sigma * tf.sqrt(self.T) * Z)
-            else:
-                dt    = self.T / tf.cast(self.n_steps, self.dtype)
-                dW    = self._brownian()
-                times = tf.range(self.n_steps, dtype=self.dtype) * dt
-                S     = tf.fill([self.n_paths], self.S0)
-                def step(prev, elems):
-                    dWi, tc = elems
-                    sig = self._sigma_fn(
-                        tf.stack([tf.fill([self.n_paths], tc), prev], axis=1)
-                    )
-                    return prev * tf.exp((self.r - 0.5 * sig**2) * dt + sig * dWi)
-                if self.use_scan:
-                    path = tf.scan(step, (dW, times), initializer=S)
-                    ST = path[-1]
-                else:
-                    ST = tf.foldl(step, (dW, times), initializer=S)
+            ST = self.asset.simulate(self.T, self.market)
+            payoff = tf.where(self.is_call, tf.nn.relu(ST - self.K), tf.nn.relu(self.K - ST))
+            price = self.market.discount_factor(self.T) * tf.reduce_mean(payoff)
 
-            payoff = tf.where(self.is_call,
-                              tf.nn.relu(ST - self.K),
-                              tf.nn.relu(self.K - ST))
-            price = tf.exp(-self.r * self.T) * tf.reduce_mean(payoff)
-
-        delta = tape.gradient(price, self.S0)
-        if self._flat_sigma is not None:
-            vega = tape.gradient(price, self._flat_sigma)
+        delta = tape.gradient(price, self.asset.S0)
+        if self.market._flat_sigma is not None:
+            vega = tape.gradient(price, self.market._flat_sigma)
         else:
-            grid_grad = tape.gradient(price, self._dupire_grid)
+            grid_grad = tape.gradient(price, self.market._dupire_grid)
             vega = tf.reduce_sum(grid_grad)
         del tape
         return price, delta, vega
@@ -246,7 +301,7 @@ class MCEuropeanOption:
         price, delta, vega = self._compute_price_and_grads()
         self._last_price = price
         self._last_delta = delta
-        self._last_vega  = vega
+        self._last_vega = vega
         return price
 
     def delta(self):
@@ -256,11 +311,11 @@ class MCEuropeanOption:
 
     @tf.function(jit_compile=True, reduce_retracing=True)
     def vega_bucket(self):
-        if self._dupire_grid is None:
+        if self.market._dupire_grid is None:
             raise ValueError("bucket-vega only available with DupireLocalVol")
         with tf.GradientTape() as tape:
             price = self.__call__()
-        return tape.gradient(price, self._dupire_grid)
+        return tape.gradient(price, self.market._dupire_grid)
 
     def vega(self):
         if self._last_vega is None:

--- a/tests/test_european_example.py
+++ b/tests/test_european_example.py
@@ -3,6 +3,8 @@ import tensorflow as tf
 from ml_greeks_pricers.pricers.european import (
     AnalyticalEuropeanOption,
     MCEuropeanOption,
+    EuropeanAsset,
+    MarketData,
 )
 from ml_greeks_pricers.volatility.discrete import DupireLocalVol
 
@@ -35,19 +37,31 @@ def test_monte_carlo_prices_close_to_analytical():
     anal = AnalyticalEuropeanOption(S0, K, T, 0, r, q, iv_vol, is_call=False)
     analytical_price = anal().numpy()
 
-    mc_flat = MCEuropeanOption(
-        S0, K, T, r, q, iv_vol,
-        n_paths=n_paths, n_steps=n_steps,
-        use_scan=True, seed=0,
+    market_flat = MarketData(r, iv_vol)
+    asset_flat = EuropeanAsset(
+        S0,
+        q,
+        T,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        use_scan=True,
+        seed=0,
     )
+    mc_flat = MCEuropeanOption(asset_flat, market_flat, K, T, is_call=False)
     flat_price = mc_flat().numpy()
 
     dup = DupireLocalVol(strikes, mats, iv, S0, r, q)
-    mc_loc = MCEuropeanOption(
-        S0, K, T, r, q, dup,
-        n_paths=n_paths, n_steps=n_steps,
-        use_scan=True, seed=0,
+    market_dup = MarketData(r, dup)
+    asset_dup = EuropeanAsset(
+        S0,
+        q,
+        T,
+        n_paths=n_paths,
+        n_steps=n_steps,
+        use_scan=True,
+        seed=0,
     )
+    mc_loc = MCEuropeanOption(asset_dup, market_dup, K, T, is_call=False)
     dupire_price = mc_loc().numpy()
 
     def check(label, price):


### PR DESCRIPTION
## Summary
- extend `EuropeanAsset` with a maximum simulation horizon
- warn when option maturity does not match the discretization grid
- update Monte Carlo pricer, example script, and tests for the new API

## Testing
- `pytest -q`