### PR TITLE
Enable cached asset paths with dt-based simulation

### DIFF
--- a/examples/cache_demo.py
+++ b/examples/cache_demo.py
@@ -1,0 +1,72 @@
+import os
+import time
+import tensorflow as tf
+
+# suppress TF logs
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'
+tf.get_logger().setLevel('ERROR')
+tf.keras.backend.set_floatx('float64')
+
+from ml_greeks_pricers.pricers.european import MarketData, MCEuropeanOption, EuropeanAsset
+from ml_greeks_pricers.volatility.discrete import DupireLocalVol
+
+# parameters copied from examples/european.py
+S0, r, q = 110., 0.06, 0.
+iv_vol = 0.212
+n_paths = 50_000
+n_steps = 100
+T_max = 2.0
+# reuse same dt as examples/european.py (0.5/100)
+dt = 0.5 / n_steps
+
+strikes = [60, 70, 80, 90, 100, 110, 120, 130, 140]
+mats = [0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.00]
+
+iv = [
+    [0.248, 0.233, 0.220, 0.209, 0.200, 0.193, 0.188, 0.185, 0.184],
+    [0.251, 0.236, 0.223, 0.212, 0.203, 0.196, 0.191, 0.188, 0.187],
+    [0.254, 0.239, 0.226, 0.215, 0.206, 0.199, 0.194, 0.191, 0.190],
+    [0.257, 0.242, 0.229, 0.218, 0.209, 0.202, 0.197, 0.194, 0.193],
+    [0.260, 0.245, 0.232, 0.221, 0.212, 0.205, 0.200, 0.197, 0.196],
+    [0.263, 0.248, 0.235, 0.224, 0.215, 0.208, 0.203, 0.200, 0.199],
+    [0.266, 0.251, 0.238, 0.227, 0.218, 0.211, 0.206, 0.203, 0.202],
+    [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],
+]
+
+market_flat = MarketData(r, iv_vol)
+dup = DupireLocalVol(strikes, mats, iv, S0, r, q)
+market_dup = MarketData(r, dup)
+
+# helper to price the full surface
+
+def price_surface(market, use_cache):
+    asset = EuropeanAsset(
+        S0,
+        q,
+        T=T_max,
+        dt=dt,
+        n_paths=n_paths,
+        use_scan=True,
+        seed=0,
+    )
+    for T in sorted(mats, reverse=True):
+        for K in strikes:
+            opt = MCEuropeanOption(asset, market, K, T, is_call=False, use_cache=use_cache)
+            opt()
+
+
+def measure(market, name, use_cache):
+    # warm-up compilation
+    warm_asset = EuropeanAsset(S0, q, T=T_max, dt=dt, n_paths=n_paths, use_scan=True, seed=0)
+    warm_opt = MCEuropeanOption(warm_asset, market, strikes[0], mats[-1], is_call=False, use_cache=use_cache)
+    warm_opt()
+    start = time.perf_counter()
+    price_surface(market, use_cache)
+    elapsed = time.perf_counter() - start
+    print(f"{name} ({'cache' if use_cache else 'no cache'}): {elapsed:.2f}s")
+
+
+if __name__ == '__main__':
+    for mkt, name in ((market_flat, 'flat'), (market_dup, 'dupire')):
+        measure(mkt, name, True)
+        measure(mkt, name, False)

--- a/examples/european.py
+++ b/examples/european.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     n_paths = 50_000
     n_steps = 100
     S0,K,T,r,q = 110.,90.,0.5,0.06,0.
+    dt = T/n_steps
     iv_vol = 0.212
     analEur = AnalyticalEuropeanOption(S0, K, T, 0, r, q, iv_vol, is_call=False)
     analytical_price = analEur().numpy()
@@ -30,8 +31,9 @@ if __name__ == '__main__':
     asset_flat = EuropeanAsset(
         S0,
         q,
+        T=T,
+        dt=dt,
         n_paths=n_paths,
-        n_steps=n_steps,
         use_scan=True,
         seed=0,
     )
@@ -60,8 +62,9 @@ if __name__ == '__main__':
     asset_dup = EuropeanAsset(
         S0,
         q,
+        T=T,
+        dt=dt,
         n_paths=n_paths,
-        n_steps=n_steps,
         use_scan=True,
         seed=0,
     )

--- a/tests/test_european_example.py
+++ b/tests/test_european_example.py
@@ -13,6 +13,7 @@ S0, K, T, r, q = 110., 90., 0.5, 0.06, 0.
 iv_vol = 0.212
 n_paths = 50_000
 n_steps = 100
+dt = T / n_steps
 
 strikes = [60, 70, 80, 90, 100, 110, 120, 130, 140]
 mats = [0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.00]
@@ -41,8 +42,9 @@ def test_monte_carlo_prices_close_to_analytical():
     asset_flat = EuropeanAsset(
         S0,
         q,
+        T=T,
+        dt=dt,
         n_paths=n_paths,
-        n_steps=n_steps,
         use_scan=True,
         seed=0,
     )
@@ -54,8 +56,9 @@ def test_monte_carlo_prices_close_to_analytical():
     asset_dup = EuropeanAsset(
         S0,
         q,
+        T=T,
+        dt=dt,
         n_paths=n_paths,
-        n_steps=n_steps,
         use_scan=True,
         seed=0,
     )


### PR DESCRIPTION
## Summary
- add time-step `dt` interface and caching logic to `EuropeanAsset`
- allow `MCEuropeanOption` to reuse cached paths
- update example script for new asset API
- add caching demo example

## Testing
- `pytest -q`