### PR TITLE
Refactor American option pricer

### DIFF
--- a/examples/american.py
+++ b/examples/american.py
@@ -1,0 +1,54 @@
+import tensorflow as tf
+
+from ml_greeks_pricers.volatility.discrete import DupireLocalVol
+from ml_greeks_pricers.pricers.european import MarketData, EuropeanAsset, MCEuropeanOption
+from ml_greeks_pricers.pricers.american import AmericanAsset, MCAmericanOption
+
+
+tf.keras.backend.set_floatx('float64')
+
+dtype = tf.float64
+
+if __name__ == "__main__":
+    S0 = 110.0
+    K = 90.0
+    r = 0.06
+    q = 0.0
+    T = 0.5
+    n_paths = 200_000
+    n_steps = 50
+    seed = 42
+
+    strikes = [60, 70, 80, 90, 100, 110, 120, 130, 140]
+    mats = [0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.00]
+    iv = [
+        [0.248, 0.233, 0.220, 0.209, 0.200, 0.193, 0.188, 0.185, 0.184],
+        [0.251, 0.236, 0.223, 0.212, 0.203, 0.196, 0.191, 0.188, 0.187],
+        [0.254, 0.239, 0.226, 0.215, 0.206, 0.199, 0.194, 0.191, 0.190],
+        [0.257, 0.242, 0.229, 0.218, 0.209, 0.202, 0.197, 0.194, 0.193],
+        [0.260, 0.245, 0.232, 0.221, 0.212, 0.205, 0.200, 0.197, 0.196],
+        [0.263, 0.248, 0.235, 0.224, 0.215, 0.208, 0.203, 0.200, 0.199],
+        [0.266, 0.251, 0.238, 0.227, 0.218, 0.211, 0.206, 0.203, 0.202],
+        [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],
+    ]
+    dupire_lv = DupireLocalVol(strikes, mats, iv, S0, r, q)
+    dupire_lv = 0.212  # constant volatility as reference
+
+    market = MarketData(r, dupire_lv)
+
+    dt = T / n_steps
+    asset_eur = EuropeanAsset(S0, q, T=T, dt=dt, n_paths=n_paths, antithetic=True, seed=seed)
+    mc_eur = MCEuropeanOption(asset_eur, market, K, T, is_call=False)
+
+    price_eur = mc_eur()
+    delta_eur = mc_eur.delta()
+    vega_eur = mc_eur.vega()
+    tf.print("European:", price_eur, "Delta:", delta_eur, "Vega:", vega_eur)
+
+    asset_amer = AmericanAsset(S0, q, T=T, dt=dt, n_paths=n_paths, antithetic=True, seed=seed)
+    mc_amer = MCAmericanOption(asset_amer, market, K, T, is_call=False)
+
+    price_amer = mc_amer()
+    delta_amer = mc_amer.delta()
+    vega_amer = mc_amer.vega()
+    tf.print("American:", price_amer, "Delta:", delta_amer, "Vega:", vega_amer)

--- a/ml_greeks_pricers/pricers/american.py
+++ b/ml_greeks_pricers/pricers/american.py
@@ -1,139 +1,160 @@
-from ml_greeks_pricers.volatility.discrete import ImpliedVolSurface, DupireLocalVol
-from ml_greeks_pricers.common.constants import USE_XLA
-from ml_greeks_pricers.common.random_cache import mc_noise
+"""Longstaff-Schwartz Monte Carlo pricer for American options."""
+
+from __future__ import annotations
 
 import tensorflow as tf
 
+from ml_greeks_pricers.pricers.european import (
+    MarketData,
+    EuropeanAsset,
+)
+from ml_greeks_pricers.common.constants import USE_XLA
+
+
+class AmericanAsset(EuropeanAsset):
+    """Simulates full price paths for the underlying asset."""
+
+    @tf.function(jit_compile=True, reduce_retracing=True)
+    def simulate(self, T, market: MarketData, *, use_cache=True) -> tf.Tensor:
+        """Return the full simulated path up to maturity ``T``."""
+
+        T_val = float(tf.get_static_value(T))
+        steps = int(round(T_val / float(tf.get_static_value(self.dt))))
+
+        if use_cache and self._cache_valid and steps <= self._cached_steps:
+            if steps == 0:
+                S = tf.fill([self.n_paths], self.S0)
+                return tf.expand_dims(S, 0)
+            dW = self._cached_dW[:steps]
+        else:
+            dW = self._brownian(steps)
+            if use_cache:
+                self._cached_dW[:steps].assign(dW)
+                self._cache_valid = True
+                self._cached_steps = steps
+
+        times = tf.range(steps, dtype=self.dtype) * self.dt
+        S = tf.fill([self.n_paths], self.S0)
+        path = tf.TensorArray(self.dtype, size=steps + 1)
+        path = path.write(0, S)
+
+        def step(prev, elems):
+            dWi, tc = elems
+            if market._flat_sigma is not None:
+                sig = tf.fill([self.n_paths], market._flat_sigma)
+            else:
+                sig = market._sigma_fn(
+                    tf.stack([tf.fill([self.n_paths], tc), prev], axis=1)
+                )
+            return prev * tf.exp((market.r - self.q - 0.5 * sig ** 2) * self.dt + sig * dWi)
+
+        for i in tf.range(steps):
+            S = step(S, (dW[i], times[i]))
+            path = path.write(i + 1, S)
+
+        return path.stack()
+
+
 class MCAmericanOption:
-    """Optimized LSM Monte Carlo pricer for American options with pathwise Greeks using GradientTape."""
+    """Monte Carlo pricer for American options using the LSM algorithm."""
+
     def __init__(
-        self, S0, K, T, r, q, vol_model,
-        *, is_call=False,
-        n_paths=100_000,
-        n_steps=60,
-        antithetic=True,
-        dtype=tf.float64,
-        seed=0
-    ):
-        if antithetic:
-            tf.debugging.assert_equal(
-                n_paths % 2,
-                0,
-                message="n_paths must be even when antithetic sampling is active",
+        self,
+        asset: AmericanAsset,
+        market: MarketData,
+        K,
+        T,
+        *,
+        is_call: bool = False,
+        use_cache: bool = True,
+    ) -> None:
+        self.asset = asset
+        self.market = market
+        self.K = tf.constant(K, dtype=asset.dtype)
+        self.T = tf.constant(T, dtype=asset.dtype)
+        self.is_call = is_call
+        self.use_cache = use_cache
+
+        self._eye3 = tf.eye(3, dtype=asset.dtype)
+        self._last_price = None
+        self._last_delta = None
+        self._last_vega = None
+
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
+    def _compute_price_and_grads(self):
+        dt = self.asset.dt
+        df = tf.exp(-self.market.r * dt)
+        n_steps = self.asset.n_steps
+
+        with tf.GradientTape(persistent=True) as tape:
+            tape.watch(self.asset.S0)
+            if self.market._flat_sigma is not None:
+                tape.watch(self.market._flat_sigma)
+            elif self.market._dupire_grid is not None:
+                tape.watch(self.market._dupire_grid)
+
+            paths = self.asset.simulate(self.T, self.market, use_cache=self.use_cache)
+
+            payoff = tf.where(
+                self.is_call,
+                tf.nn.relu(paths - self.K),
+                tf.nn.relu(self.K - paths),
             )
 
-        # parameters
-        self.S0 = tf.Variable(S0, dtype=dtype, trainable=True)
-        self.K  = tf.constant(K,  dtype=dtype)
-        self.T  = tf.constant(T,  dtype=dtype)
-        self.r  = tf.constant(r,  dtype=dtype)
-        self.q  = tf.constant(q,  dtype=dtype)
-        self.is_call = is_call
-        self.n_paths = n_paths
-        self.n_steps = n_steps
-        self.antithetic = antithetic
-        self.dtype = dtype
-        self._dt = self.T / tf.cast(n_steps, dtype)
-        self._times = tf.cast(tf.range(n_steps), dtype) * self._dt
-        self.seed = seed
-        self._I3 = tf.eye(3, dtype=dtype)
-
-        # volatility
-        self._flat_sigma = None
-        self._dupire_grid = None
-        self._sigma_fn = self._init_sigma_fn(vol_model)
-
-    def _init_sigma_fn(self, vm):
-        if isinstance(vm, (float, int)):
-            sigma = tf.Variable(float(vm), dtype=self.dtype, trainable=True)
-            self._flat_sigma = sigma
-            def sig_fn(inputs):
-                return tf.fill([tf.shape(inputs)[0]], sigma)
-            return sig_fn
-
-        if isinstance(vm, DupireLocalVol):
-            grid = tf.Variable(vm.surface, dtype=self.dtype, trainable=True)
-            self._dupire_grid = grid
-            strikes = tf.convert_to_tensor(vm.strikes, dtype=self.dtype)
-            mats    = tf.convert_to_tensor(vm.maturities, dtype=self.dtype)
-            def sig_fn(inputs):
-                t = inputs[:,0]; s = inputs[:,1]
-                return ImpliedVolSurface.bilinear(t, s, grid, strikes, mats)
-            return sig_fn
-
-        raise TypeError("vol_model must be float/int or DupireLocalVol")
-
-    @tf.function(jit_compile=USE_XLA)
-    def price_and_grads(self):
-        # generate paths and price under one tape for gradients
-        with tf.GradientTape(persistent=True) as tape:
-            tape.watch(self.S0)
-            if self._flat_sigma is not None:
-                tape.watch(self._flat_sigma)
-            if self._dupire_grid is not None:
-                tape.watch(self._dupire_grid)
-
-            # simulate Brownian increments
-            Z = mc_noise(self.n_steps, self.n_paths, self.seed, antithetic=self.antithetic, dtype=self.dtype)
-            dW = Z * tf.sqrt(self._dt)
-
-            # simulate asset paths
-            S = tf.fill([self.n_paths], self.S0)
-            paths = tf.TensorArray(self.dtype, size=self.n_steps+1)
-            paths = paths.write(0, S)
-            for i in tf.range(self.n_steps):
-                t = self._times[i]
-                X = tf.stack([tf.fill([self.n_paths], t), S], axis=1)
-                sigma_t = self._sigma_fn(X)
-                S = S * tf.exp((self.r - 0.5*sigma_t**2)*self._dt + sigma_t*dW[i])
-                paths = paths.write(i+1, S)
-            paths = paths.stack()
-
-            # LSM backward induction
-            df = tf.exp(-self.r*self._dt)
-            pay = tf.where(self.is_call, tf.nn.relu(paths-self.K), tf.nn.relu(self.K-paths))
-            CF = pay[-1]
-            eps = tf.cast(1e-6, self.dtype)
-            for t in tf.range(self.n_steps-1, 0, -1):
+            CF = payoff[-1]
+            eps = tf.cast(1e-6, self.asset.dtype)
+            for t in tf.range(n_steps - 1, 0, -1):
                 discounted = CF * df
                 St = paths[t]
-                itm = pay[t] > 0
-                idx = tf.where(itm)[:,0]
+                itm = payoff[t] > 0
+                idx = tf.where(itm)[:, 0]
                 St_i = tf.gather(St, idx)
                 CF_i = tf.gather(discounted, idx)
-                Xmat = tf.stack([tf.ones_like(St_i), St_i, St_i**2], axis=1)
-                XTX = tf.matmul(Xmat, Xmat, transpose_a=True)
-                XTC = tf.matmul(Xmat, CF_i[:,None], transpose_a=True)
-                beta = tf.linalg.solve(XTX + eps*self._I3, XTC)
+                X = tf.stack([tf.ones_like(St_i), St_i, St_i ** 2], axis=1)
+                XTX = tf.matmul(X, X, transpose_a=True)
+                XTC = tf.matmul(X, CF_i[:, None], transpose_a=True)
+                beta = tf.linalg.solve(XTX + eps * self._eye3, XTC)
                 beta = tf.reshape(beta, [3])
-                cont = beta[0] + beta[1]*St + beta[2]*St**2
-                exercise = itm & (pay[t] > cont)
-                CF = tf.where(exercise, pay[t], discounted)
-            price = tf.reduce_mean(CF*df)
+                cont = beta[0] + beta[1] * St + beta[2] * St ** 2
+                exercise = itm & (payoff[t] > cont)
+                CF = tf.where(exercise, payoff[t], discounted)
 
-        # gradients
-        delta = tape.gradient(price, self.S0)
-        if self._flat_sigma is not None:
-            vega = tape.gradient(price, self._flat_sigma)
-        elif self._dupire_grid is not None:
-            ggrid = tape.gradient(price, self._dupire_grid)
-            vega = tf.reduce_sum(ggrid)
+            price = tf.reduce_mean(CF * df)
+
+        delta = tape.gradient(price, self.asset.S0)
+        if delta is None:
+            delta = tf.zeros_like(self.asset.S0)
+
+        if self.market._flat_sigma is not None:
+            vega = tape.gradient(price, self.market._flat_sigma)
+            if vega is None:
+                vega = tf.zeros_like(self.market._flat_sigma)
         else:
-            vega = None
+            grid_grad = tape.gradient(price, self.market._dupire_grid)
+            if grid_grad is None:
+                grid_grad = tf.zeros_like(self.market._dupire_grid)
+            vega = tf.reduce_sum(grid_grad)
+
         del tape
         return price, delta, vega
 
     def __call__(self):
-        p, d, v = self.price_and_grads()
-        self._last_price, self._last_delta, self._last_vega = p, d, v
-        return p
+        price, delta, vega = self._compute_price_and_grads()
+        self._last_price = price
+        self._last_delta = delta
+        self._last_vega = vega
+        return price
 
     def delta(self):
-        if not hasattr(self, '_last_delta'):
-            _ = self()
+        if self._last_delta is None:
+            _ = self.__call__()
         return self._last_delta
 
     def vega(self):
-        if not hasattr(self, '_last_vega'):
-            _ = self()
+        if self._last_vega is None:
+            _ = self.__call__()
         return self._last_vega
+
+
+__all__ = ["MarketData", "AmericanAsset", "MCAmericanOption"]
+


### PR DESCRIPTION
## Summary
- refactor `MCAmericanOption` to use the same asset/market structure as the european pricer
- implement `AmericanAsset` that generates full paths
- add simple demo comparing european vs american pricing

## Testing
- `pytest tests/test_european_example.py::test_monte_carlo_prices_close_to_analytical -q`
- `pytest tests/test_european_example.py::test_monte_carlo_greeks_close_to_analytical -q`
