### PR TITLE
Fix american simulation steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Fix AmericanAsset.simulate failing under XLA when called from `tf.function` by using cached `n_steps` instead of `tf.get_static_value`.

--- a/ml_greeks_pricers/pricers/american.py
+++ b/ml_greeks_pricers/pricers/american.py
@@ -18,8 +18,11 @@ class AmericanAsset(EuropeanAsset):
     def simulate(self, T, market: MarketData, *, use_cache=True) -> tf.Tensor:
         """Return the full simulated path up to maturity ``T``."""
 
-        T_val = float(tf.get_static_value(T))
-        steps = int(round(T_val / float(tf.get_static_value(self.dt))))
+        # ``self.n_steps`` already stores the integer number of steps derived
+        # from ``T`` and ``dt`` at construction time.  Using it directly avoids
+        # calling ``tf.get_static_value`` on symbolic tensors, which fails when
+        # ``simulate`` is invoked from a ``tf.function``.
+        steps = self.n_steps
 
         if use_cache and self._cache_valid and steps <= self._cached_steps:
             if steps == 0:

--- a/tests/test_american_option.py
+++ b/tests/test_american_option.py
@@ -1,0 +1,35 @@
+import pytest
+import tensorflow as tf
+
+from ml_greeks_pricers.pricers.american import AmericanAsset, MCAmericanOption
+from ml_greeks_pricers.pricers.european import MarketData
+
+
+tf.keras.backend.set_floatx("float64")
+
+
+def test_monte_carlo_american():
+    S0, K, r, q, T = 110.0, 90.0, 0.06, 0.0, 0.5
+    n_paths, n_steps, seed = 200_000, 100, 42
+    dt = T / n_steps
+    sigma = 0.212
+
+    market = MarketData(r, sigma)
+    asset = AmericanAsset(
+        S0,
+        q,
+        T=T,
+        dt=dt,
+        n_paths=n_paths,
+        antithetic=True,
+        seed=seed,
+    )
+    option = MCAmericanOption(asset, market, K, T, is_call=False)
+
+    price = float(option())
+    delta = float(option.delta())
+    vega = float(option.vega())
+
+    assert price == pytest.approx(0.39972271913087026, rel=1e-2, abs=1e-3)
+    assert delta == pytest.approx(-0.054422702022917754, rel=1e-2, abs=1e-3)
+    assert vega == pytest.approx(8.5237423677645676, rel=1e-2, abs=1e-2)


### PR DESCRIPTION
## Summary
- use cached n_steps in AmericanAsset.simulate
- regression test for american option
- add changelog entry

## Testing
- `pytest tests/test_american_option.py::test_monte_carlo_american -q`
- `pytest tests/test_european_example.py::test_monte_carlo_prices_close_to_analytical -q`
- `pytest tests/test_cache_surface.py::test_surface_diff_with_cache -q` *(fails: KeyboardInterrupt)*