### PR TITLE
Add unified logging and optional XLA

### DIFF
--- a/examples/european.py
+++ b/examples/european.py
@@ -1,12 +1,13 @@
+import os
+import warnings
+import time
+from datetime import datetime
+from pathlib import Path
 import tensorflow as tf
+
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'
+tf.get_logger().setLevel('ERROR')
 tf.keras.backend.set_floatx('float64')
-tf.keras.backend.clear_session()  
-
-
-import os, warnings, re, tensorflow as tf
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'   # suprime avisos de backend C++
-tf.get_logger().setLevel('ERROR')          # suprime avisos Python de TF
-
 
 from ml_greeks_pricers.pricers.european import (
     AnalyticalEuropeanOption,
@@ -14,19 +15,21 @@ from ml_greeks_pricers.pricers.european import (
     MarketData,
     EuropeanAsset,
 )
-from ml_greeks_pricers.volatility.discrete import ImpliedVolSurface, DupireLocalVol
-
+from ml_greeks_pricers.volatility.discrete import DupireLocalVol
 
 if __name__ == '__main__':
     n_paths = 50_000
     n_steps = 100
-    S0,K,T,r,q = 110.,90.,0.5,0.06,0.
-    dt = T/n_steps
+    S0, K, T, r, q = 110., 90., 0.5, 0.06, 0.
+    dt = T / n_steps
+    log_path = Path(__file__).with_name('execution.log')
+
     iv_vol = 0.212
     analEur = AnalyticalEuropeanOption(S0, K, T, 0, r, q, iv_vol, is_call=False)
     analytical_price = analEur().numpy()
     tf.print('analytical', analytical_price, analEur.delta(), analEur.vega())
-    # ---- volatilidad constante ---------------------------------------
+
+    # ---- constant volatility ----
     market_flat = MarketData(r, iv_vol)
     asset_flat = EuropeanAsset(
         S0,
@@ -38,23 +41,27 @@ if __name__ == '__main__':
         seed=0,
     )
     mc_flat = MCEuropeanOption(asset_flat, market_flat, K, T, is_call=False)
+    mc_flat()  # warm-up
+    start = time.perf_counter()
     flat_price = mc_flat().numpy()
-    tf.print('flat', flat_price, mc_flat.delta(), mc_flat.vega())
+    flat_delta = mc_flat.delta().numpy()
+    flat_vega = mc_flat.vega().numpy()
+    elapsed_flat = time.perf_counter() - start
+    tf.print('flat', flat_price, flat_delta, flat_vega)
 
     # ---- Dupire local-vol --------------------------------------------
     strikes = [60, 70, 80, 90, 100, 110, 120, 130, 140]
     mats = [0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.00]
 
     iv = [
-        #  sigma_IV(T , K )
-        [0.248, 0.233, 0.220, 0.209, 0.200, 0.193, 0.188, 0.185, 0.184],  # T=0.25
-        [0.251, 0.236, 0.223, 0.212, 0.203, 0.196, 0.191, 0.188, 0.187],  # 0.50
-        [0.254, 0.239, 0.226, 0.215, 0.206, 0.199, 0.194, 0.191, 0.190],  # 0.75
-        [0.257, 0.242, 0.229, 0.218, 0.209, 0.202, 0.197, 0.194, 0.193],  # 1.00
-        [0.260, 0.245, 0.232, 0.221, 0.212, 0.205, 0.200, 0.197, 0.196],  # 1.25
-        [0.263, 0.248, 0.235, 0.224, 0.215, 0.208, 0.203, 0.200, 0.199],  # 1.50
-        [0.266, 0.251, 0.238, 0.227, 0.218, 0.211, 0.206, 0.203, 0.202],  # 1.75
-        [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],  # 2.00
+        [0.248, 0.233, 0.220, 0.209, 0.200, 0.193, 0.188, 0.185, 0.184],
+        [0.251, 0.236, 0.223, 0.212, 0.203, 0.196, 0.191, 0.188, 0.187],
+        [0.254, 0.239, 0.226, 0.215, 0.206, 0.199, 0.194, 0.191, 0.190],
+        [0.257, 0.242, 0.229, 0.218, 0.209, 0.202, 0.197, 0.194, 0.193],
+        [0.260, 0.245, 0.232, 0.221, 0.212, 0.205, 0.200, 0.197, 0.196],
+        [0.263, 0.248, 0.235, 0.224, 0.215, 0.208, 0.203, 0.200, 0.199],
+        [0.266, 0.251, 0.238, 0.227, 0.218, 0.211, 0.206, 0.203, 0.202],
+        [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],
     ]
     dup = DupireLocalVol(strikes, mats, iv, S0, r, q)
 
@@ -69,8 +76,13 @@ if __name__ == '__main__':
         seed=0,
     )
     mc_loc = MCEuropeanOption(asset_dup, market_dup, K, T, is_call=False)
+    mc_loc()  # warm-up
+    start = time.perf_counter()
     dupire_price = mc_loc().numpy()
-    tf.print('dupire', dupire_price, mc_loc.delta(), mc_loc.vega())
+    dupire_delta = mc_loc.delta().numpy()
+    dupire_vega = mc_loc.vega().numpy()
+    elapsed_dup = time.perf_counter() - start
+    tf.print('dupire', dupire_price, dupire_delta, dupire_vega)
 
     def warn_if_far(name, price):
         diff = abs(price - analytical_price) / analytical_price
@@ -82,3 +94,11 @@ if __name__ == '__main__':
 
     warn_if_far('flat', flat_price)
     warn_if_far('dupire', dupire_price)
+
+    with log_path.open('a') as f:
+        f.write(
+            f"{datetime.now().isoformat()} european n_steps={n_steps} n_paths={n_paths} "
+            f"flat_time={elapsed_flat:.4f} dupire_time={elapsed_dup:.4f} "
+            f"flat_price={flat_price:.6f} flat_delta={flat_delta:.6f} flat_vega={flat_vega:.6f} "
+            f"dupire_price={dupire_price:.6f} dupire_delta={dupire_delta:.6f} dupire_vega={dupire_vega:.6f}\n"
+        )

--- a/ml_greeks_pricers/pricers/american.py
+++ b/ml_greeks_pricers/pricers/american.py
@@ -14,7 +14,7 @@ from ml_greeks_pricers.common.constants import USE_XLA
 class AmericanAsset(EuropeanAsset):
     """Simulates full price paths for the underlying asset."""
 
-    @tf.function(reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def simulate(self, T, market: MarketData, *, use_cache=True) -> tf.Tensor:
         """Return the full simulated path up to maturity ``T``."""
 
@@ -85,7 +85,7 @@ class MCAmericanOption:
         self._last_delta = None
         self._last_vega = None
 
-    @tf.function(reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def _compute_price_and_grads(self):
         dt = self.asset.dt
         df = tf.exp(-self.market.r * dt)

--- a/ml_greeks_pricers/pricers/black_utils.py
+++ b/ml_greeks_pricers/pricers/black_utils.py
@@ -1,6 +1,8 @@
 import tensorflow as tf
+from ml_greeks_pricers.common.constants import USE_XLA
+
 tf.keras.backend.set_floatx('float64')
-@tf.function(reduce_retracing=True)
+@tf.function(jit_compile=USE_XLA, reduce_retracing=True)
 def bs_price(
     S:     tf.Tensor,
     K:     tf.Tensor,

--- a/ml_greeks_pricers/pricers/european.py
+++ b/ml_greeks_pricers/pricers/european.py
@@ -28,7 +28,7 @@ class AnalyticalEuropeanOption:
         self.is_call = is_call
 
     @staticmethod
-    @tf.function(reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def bs_price(
         S:     tf.Tensor,
         K:     tf.Tensor,
@@ -61,7 +61,7 @@ class AnalyticalEuropeanOption:
 
         return tf.where(is_call, call, put)
 
-    @tf.function(reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def price(self) -> tf.Tensor:
         return self.bs_price(
             self.S, self.K, self.T, self.t, self.r, self.q, self.sigma, self.is_call
@@ -237,7 +237,7 @@ class EuropeanAsset:
         self._cache_valid = False
         self._cached_steps = 0
 
-    @tf.function(jit_compile=True, reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def _brownian(self, n_steps):
         """Generate Brownian increments for ``n_steps`` using cached ``dt``."""
         M = tf.cast(n_steps, tf.int32)
@@ -308,7 +308,7 @@ class MCEuropeanOption:
         self._last_delta = None
         self._last_vega = None
 
-    @tf.function(jit_compile=True, reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def _compute_price_and_grads(self):
         with tf.GradientTape(persistent=True) as tape:
             tape.watch(self.asset.S0)
@@ -358,7 +358,7 @@ class MCEuropeanOption:
             _ = self.__call__()
         return self._last_delta
 
-    @tf.function(jit_compile=True, reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def vega_bucket(self):
         if self.market._dupire_grid is None:
             raise ValueError("bucket-vega only available with DupireLocalVol")

--- a/ml_greeks_pricers/volatility/discrete.py
+++ b/ml_greeks_pricers/volatility/discrete.py
@@ -47,7 +47,7 @@ class DupireLocalVol(ImpliedVolSurface):
         self.surface = self._compute_surface()
         self.grid    = self.surface
 
-    @tf.function(jit_compile=True, reduce_retracing=True)
+    @tf.function(jit_compile=USE_XLA, reduce_retracing=True)
     def _compute_surface(self):
         strikes, mats, iv = self.strikes, self.maturities, self.grid
         S0, r, q         = self.S0, self.r, self.q


### PR DESCRIPTION
## Summary
- log execution statistics for example scripts
- toggle XLA compilation using constant `USE_XLA`
- update american and european examples to log prices, greeks and timings
- log timings from *_surfaces.py scripts
- allow toggling XLA on main TensorFlow functions

## Testing
- `pytest -q`