### PR TITLE
Add vectorization support for MCEuropeanOption

### DIFF
--- a/tests/test_vector_mc_european.py
+++ b/tests/test_vector_mc_european.py
@@ -1,0 +1,40 @@
+import tensorflow as tf
+import numpy as np
+from ml_greeks_pricers.pricers.european import (
+    AnalyticalEuropeanOption,
+    MCEuropeanOption,
+    EuropeanAsset,
+    MarketData,
+)
+
+def test_vector_monte_carlo_prices():
+    tf.keras.backend.set_floatx("float64")
+    S = tf.constant([110.0, 120.0], dtype=tf.float64)
+    K = tf.constant([90.0, 100.0], dtype=tf.float64)
+    T = tf.constant(0.5, dtype=tf.float64)
+    r = tf.constant(0.06, dtype=tf.float64)
+    q = tf.constant(0.0, dtype=tf.float64)
+    sigma = tf.constant(0.212, dtype=tf.float64)
+
+    anal = AnalyticalEuropeanOption(S, K, T, 0.0, r, q, sigma, is_call=False)
+    analytical = anal.price().numpy()
+
+    n_paths = 20_000
+    n_steps = 50
+    dt = float(T.numpy()) / n_steps
+
+    asset = EuropeanAsset(
+        S,
+        q,
+        T=float(T.numpy()),
+        dt=dt,
+        n_paths=n_paths,
+        use_scan=True,
+        seed=0,
+    )
+    market = MarketData(r, float(sigma.numpy()))
+    mc = MCEuropeanOption(asset, market, K, T, is_call=False)
+    price = mc().numpy()
+
+    diff = np.abs(price - analytical) / analytical
+    assert np.all(diff < 0.1)


### PR DESCRIPTION
## Summary
- allow `EuropeanAsset` and `MarketData` to handle vector inputs
- refactor Monte Carlo pricers to work with multiple spots at once
- keep American option behaviour unchanged
- add regression test for vectorised European pricing

## Testing
- `pytest tests/test_european_example.py::test_monte_carlo_prices_close_to_analytical -q`
- `pytest tests/test_european_example.py::test_monte_carlo_greeks_close_to_analytical -q`
- `pytest tests/test_american_option.py -q`
- `pytest tests/test_cache_surface.py -q`
- `pytest tests/test_vector_mc_european.py -q`


------
https://chatgpt.com/codex/tasks/task_e_683c2ff61e3c832a98bc609c16502923