### PR TITLE
Refactor NN BlackScholes to MCEuropeanOption

### DIFF
--- a/examples/nn_european.py
+++ b/examples/nn_european.py
@@ -3,7 +3,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from ml_greeks_pricers.nn import BlackScholes, run_test
+from ml_greeks_pricers.nn import MCEuropeanOption, run_test
+from ml_greeks_pricers.pricers.european import MarketData, EuropeanAsset
 
 
 def plot(title, pred, x, y, sizes, ylabel):
@@ -28,7 +29,9 @@ if __name__ == "__main__":
     n_test = 100
     seed = np.random.randint(1e4)
     print(f"seed {seed}")
-    gen = BlackScholes()
+    market = MarketData(0.0, 0.2)
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=1.0, n_paths=1)
+    gen = MCEuropeanOption(market, asset)
     x, y, dy, vp, dp = run_test(gen, sizes, n_test, seed)
     plot("Black-Scholes values", vp, x, y, sizes, "value")
     plot("Black-Scholes deltas", dp, x, dy, sizes, "delta")

--- a/ml_greeks_pricers/nn/__init__.py
+++ b/ml_greeks_pricers/nn/__init__.py
@@ -7,7 +7,7 @@ from .black_scholes import (
     bs_price,
     bs_delta,
     bs_vega,
-    BlackScholes,
+    MCEuropeanOption,
     NeuralApproximator,
     run_test,
 )
@@ -24,7 +24,7 @@ __all__ = [
     "bs_price",
     "bs_delta",
     "bs_vega",
-    "BlackScholes",
+    "MCEuropeanOption",
     "NeuralApproximator",
     "run_test",
 ]

--- a/tests/test_nn_european_example.py
+++ b/tests/test_nn_european_example.py
@@ -3,9 +3,10 @@ import tensorflow as tf
 from ml_greeks_pricers.nn import (
     bs_price,
     bs_delta,
-    BlackScholes,
+    MCEuropeanOption,
     NeuralApproximator,
 )
+from ml_greeks_pricers.pricers.european import MarketData, EuropeanAsset
 
 
 def test_bs_functions():
@@ -16,7 +17,9 @@ def test_bs_functions():
 
 
 def test_training_set_reproducible():
-    gen = BlackScholes()
+    market = MarketData(0.0, 0.2)
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=0.5, n_paths=2)
+    gen = MCEuropeanOption(market, asset)
     x, y, dy = gen.training_set(3, seed=0)
     assert x.shape == (3, 1)
     assert y.shape == (3, 1)
@@ -28,7 +31,9 @@ def test_training_set_reproducible():
 
 def test_neural_approximator_shapes():
     tf.keras.backend.set_floatx("float32")
-    gen = BlackScholes()
+    market = MarketData(0.0, 0.2)
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=0.5, n_paths=2)
+    gen = MCEuropeanOption(market, asset)
     x, y, dy = gen.training_set(20, seed=1)
     na = NeuralApproximator(x, y, dy)
     na.prepare(10, diff=False, hu=2, hl=1)


### PR DESCRIPTION
## Summary
- rename `BlackScholes` in the `nn` package to `MCEuropeanOption`
- initialise the generator with `MarketData` and `EuropeanAsset`
- update exports and example script
- adapt unit tests to the new interface

## Testing
- `pytest -q tests/test_nn_european_example.py`
- `pytest -q tests/test_vector_mc_european.py`
- `pytest -q tests/test_cache_surface.py -k cache -vv` *(execution interrupted due to long runtime)*