### PR TITLE
Add example saving NN model and show analytical curve

### DIFF
--- a/examples/nn_european.py
+++ b/examples/nn_european.py
@@ -2,18 +2,24 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
+import tensorflow as tf
 
 from ml_greeks_pricers.nn import MCEuropeanOption, run_test
-from ml_greeks_pricers.pricers.european import MarketData, EuropeanAsset
+from ml_greeks_pricers.pricers.european import (
+    MarketData,
+    EuropeanAsset,
+    AnalyticalEuropeanOption,
+)
 
 
-def plot(title, pred, x, y, sizes, ylabel):
+def plot(title, pred, ana, x, y, sizes, ylabel):
     rows = len(sizes)
     fig, ax = plt.subplots(rows, 2, figsize=(9, 4 * rows))
     for i, sz in enumerate(sizes):
         for j, kind in enumerate(("std", "diff")):
             ax[i, j].plot(x * 100, pred[(kind, sz)] * 100, "co", ms=2, mfc="w", label="pred")
             ax[i, j].plot(x * 100, y * 100, "r.", ms=0.5, label="target")
+            ax[i, j].plot(x * 100, ana * 100, "g--", lw=1, label="analytical")
             ax[i, j].set_xlabel("spot (%)")
             ax[i, j].set_ylabel(ylabel)
             if i == 0:
@@ -33,5 +39,20 @@ if __name__ == "__main__":
     asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=1.0, n_paths=1)
     gen = MCEuropeanOption(market, asset)
     x, y, dy, vp, dp = run_test(gen, sizes, n_test, seed)
-    plot("Black-Scholes values", vp, x, y, sizes, "value")
-    plot("Black-Scholes deltas", dp, x, dy, sizes, "delta")
+
+    T = gen.T2 - gen.T1
+    ana = AnalyticalEuropeanOption(
+        tf.constant(x, dtype=tf.float32),
+        gen.K,
+        T,
+        0.0,
+        market.r,
+        asset.q,
+        market._flat_sigma,
+        is_call=True,
+    )
+    v_ana = ana.price().numpy().reshape(-1, 1)
+    d_ana = ana.delta().numpy().reshape(-1, 1)
+
+    plot("Black-Scholes values", vp, v_ana[:, 0], x, y, sizes, "value")
+    plot("Black-Scholes deltas", dp, d_ana[:, 0], x, dy, sizes, "delta")

--- a/examples/nn_model_save.py
+++ b/examples/nn_model_save.py
@@ -1,0 +1,45 @@
+import pickle
+from pathlib import Path
+
+import numpy as np
+import tensorflow as tf
+
+from ml_greeks_pricers.nn import MCEuropeanOption, NeuralApproximator, TwinNetwork
+from ml_greeks_pricers.pricers.european import MarketData, EuropeanAsset
+
+
+if __name__ == "__main__":
+    tf.keras.backend.set_floatx("float32")
+
+    model_path = Path(__file__).with_suffix(".keras")
+    scaler_path = Path(__file__).with_suffix(".pkl")
+
+    market = MarketData(0.0, 0.2)
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=1.0, n_paths=1)
+    gen = MCEuropeanOption(market, asset)
+
+    x_tr, y_tr, dy_tr = gen.training_set(4096, seed=0)
+    approximator = NeuralApproximator(x_tr, y_tr, dy_tr)
+    approximator.prepare(4096, diff=True)
+    approximator.train()
+
+    approximator.twin.save(model_path)
+    with open(scaler_path, "wb") as fh:
+        pickle.dump(approximator.scaler, fh)
+
+    loaded = tf.keras.models.load_model(
+        model_path,
+        compile=False,
+        custom_objects={"TwinNetwork": TwinNetwork},
+    )
+    with open(scaler_path, "rb") as fh:
+        scaler = pickle.load(fh)
+
+    x_te, _, y_te, dy_te, _ = gen.test_set(n=100)
+    x_s = scaler.x_transform(x_te)
+    y_s, dy_s = loaded.predict(x_s, verbose=0)
+    y_pred, dy_pred = scaler.inverse(y_s, dy_s)
+
+    print("target", y_te[:5].flatten())
+    print("pred", y_pred[:5, 0])
+    print("delta", dy_pred[:5, 0])


### PR DESCRIPTION
## Summary
- add new `nn_model_save.py` example demonstrating how to save a trained model and use it for predictions
- enhance `nn_european.py` plotting with analytical Black–Scholes curve

## Testing
- `python -m py_compile examples/nn_european.py examples/nn_model_save.py`
- `pytest -q` *(fails to complete due to long execution; interrupted after ~90s)*