### PR TITLE
Fix examples and model serialization

### DIFF
--- a/examples/nn_european.py
+++ b/examples/nn_european.py
@@ -36,13 +36,18 @@ if __name__ == "__main__":
     seed = np.random.randint(1e4)
     print(f"seed {seed}")
     market = MarketData(0.0, 0.2)
-    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=1.0, n_paths=1)
+    # Use an even number of paths and steps when antithetic sampling is enabled
+    # (default behaviour).  ``dt=0.5`` ensures that ``n_steps`` is even for
+    # ``T=1.0``.
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=0.5, n_paths=2)
     gen = MCEuropeanOption(market, asset)
     x, y, dy, vp, dp = run_test(gen, sizes, n_test, seed)
 
     T = gen.T2 - gen.T1
+    # ``run_test`` returns float32 arrays, while the analytical pricer uses
+    # float64.  Cast the input to avoid dtype mismatches.
     ana = AnalyticalEuropeanOption(
-        tf.constant(x, dtype=tf.float32),
+        tf.constant(x, dtype=tf.float64),
         gen.K,
         T,
         0.0,

--- a/examples/nn_model_save.py
+++ b/examples/nn_model_save.py
@@ -15,7 +15,9 @@ if __name__ == "__main__":
     scaler_path = Path(__file__).with_suffix(".pkl")
 
     market = MarketData(0.0, 0.2)
-    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=1.0, n_paths=1)
+    # ``EuropeanAsset`` defaults to antithetic sampling.  Use an even number of
+    # paths and time steps to avoid assertion errors during initialisation.
+    asset = EuropeanAsset(1.0, 0.0, T=1.0, dt=0.5, n_paths=2)
     gen = MCEuropeanOption(market, asset)
 
     x_tr, y_tr, dy_tr = gen.training_set(4096, seed=0)


### PR DESCRIPTION
## Summary
- adjust example asset parameters to satisfy antithetic parity
- cast inputs correctly for analytical pricing
- provide serialization for custom TwinNetwork and WeightedMeanSquaredError

## Testing
- `pytest tests/test_nn_european_example.py::test_neural_approximator_shapes -q`
- `pytest tests/test_vector_mc_european.py -q`
- `pytest tests/test_european_example.py -q`
- `pytest tests/test_cache_surface.py::test_surface_diff_with_cache -q` *(interrupted due to runtime)*