### PR TITLE
Fix TwinNetwork config serialization

### DIFF
--- a/ml_greeks_pricers/nn/models.py
+++ b/ml_greeks_pricers/nn/models.py
@@ -28,7 +28,10 @@ class TwinNetwork(tf.keras.Model):
         return y, dy
 
     def get_config(self):
-        config = super().get_config()
+        """Return serializable config for the network."""
+        # Explicitly call the base class implementation instead of ``super()``
+        # to avoid ``TypeError`` when saving models in some environments.
+        config = tf.keras.Model.get_config(self)
         config["vanilla"] = tf.keras.utils.serialize_keras_object(self.vanilla)
         return config
 


### PR DESCRIPTION
## Summary
- fix error when saving `TwinNetwork` models by calling Model.get_config directly

## Testing
- `pytest -k nn_european_example -q`

------
https://chatgpt.com/codex/tasks/task_e_683c99ade2ac832a83890feff1775719