### PR TITLE
Use asset-based simulation for NN data

### DIFF
--- a/tests/test_nn_european_example.py
+++ b/tests/test_nn_european_example.py
@@ -24,8 +24,8 @@ def test_training_set_reproducible():
     assert x.shape == (3, 1)
     assert y.shape == (3, 1)
     assert dy.shape == (3, 1)
-    assert np.isclose(x[0, 0], 1.6229017)
-    assert np.isclose(y[0, 0], 0.49586323)
+    assert np.isclose(x[0, 0], 1.3948829)
+    assert np.isclose(y[0, 0], 0.27164337)
     assert np.isclose(dy[0, 0], 0.9833394)
 
 


### PR DESCRIPTION
## Summary
- simulate training data via `EuropeanAsset` instead of closed form
- store extra parameters in `MCEuropeanOption`
- update NN example tests for new reproducible outputs

## Testing
- `pytest tests/test_nn_european_example.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683ca7f09e08832aa9d3f5b41ac04844