### PR TITLE
Fix numpy compare example

### DIFF
--- a/examples/tf_vs_np/compare.py
+++ b/examples/tf_vs_np/compare.py
@@ -27,6 +27,7 @@ def compare_european():
 
     print("European TF:", price_tf)
     print("European NP:", price_np)
+    print("Close:", np.isclose(price_tf, price_np, rtol=5e-2))
 
 
 def compare_american():
@@ -47,6 +48,7 @@ def compare_american():
 
     print("American TF:", price_tf)
     print("American NP:", price_np)
+    print("Close:", np.isclose(price_tf, price_np, rtol=5e-2))
 
 
 if __name__ == "__main__":

--- a/ml_greeks_pricers/pricers/np/european.py
+++ b/ml_greeks_pricers/pricers/np/european.py
@@ -1,5 +1,6 @@
 import numpy as np
 from dataclasses import dataclass
+from math import erf
 from .black_utils import bs_price
 
 @dataclass


### PR DESCRIPTION
## Summary
- fix undefined `erf` in NumPy pricer
- update compare example to report closeness

## Testing
- `pytest -q`
- `python examples/tf_vs_np/compare.py | tail -n 6`

------
https://chatgpt.com/codex/tasks/task_e_68541d14f0ac832aade7f06b74ecb305