### PR TITLE
Add numpy Dupire local volatility utilities and comparison example

### DIFF
--- a/examples/tf_vs_np/compare_dupire.py
+++ b/examples/tf_vs_np/compare_dupire.py
@@ -1,0 +1,48 @@
+import numpy as np
+import tensorflow as tf
+
+from ml_greeks_pricers.pricers.tf import european as tf_eur
+from ml_greeks_pricers.pricers.np import european as np_eur
+from ml_greeks_pricers.volatility.discrete import DupireLocalVol as TfDupire
+from ml_greeks_pricers.volatility.np_discrete import DupireLocalVol as NpDupire
+
+
+tf.keras.backend.set_floatx("float64")
+
+def compare_dupire():
+    S0, K, r, q, T = 110.0, 90.0, 0.06, 0.0, 0.5
+    n_paths, n_steps = 50_000, 100
+    dt = T / n_steps
+
+    strikes = [60, 70, 80, 90, 100, 110, 120, 130, 140]
+    mats = [0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.00]
+    iv = [
+        [0.248, 0.233, 0.220, 0.209, 0.200, 0.193, 0.188, 0.185, 0.184],
+        [0.251, 0.236, 0.223, 0.212, 0.203, 0.196, 0.191, 0.188, 0.187],
+        [0.254, 0.239, 0.226, 0.215, 0.206, 0.199, 0.194, 0.191, 0.190],
+        [0.257, 0.242, 0.229, 0.218, 0.209, 0.202, 0.197, 0.194, 0.193],
+        [0.260, 0.245, 0.232, 0.221, 0.212, 0.205, 0.200, 0.197, 0.196],
+        [0.263, 0.248, 0.235, 0.224, 0.215, 0.208, 0.203, 0.200, 0.199],
+        [0.266, 0.251, 0.238, 0.227, 0.218, 0.211, 0.206, 0.203, 0.202],
+        [0.269, 0.254, 0.241, 0.230, 0.221, 0.214, 0.209, 0.206, 0.205],
+    ]
+
+    dup_tf = TfDupire(strikes, mats, iv, S0, r, q)
+    market_tf = tf_eur.MarketData(r, dup_tf)
+    asset_tf = tf_eur.EuropeanAsset(S0, q, T=T, dt=dt, n_paths=n_paths, use_scan=True, seed=0)
+    opt_tf = tf_eur.MCEuropeanOption(asset_tf, market_tf, K, T, is_call=False)
+    price_tf = opt_tf().numpy()
+
+    dup_np = NpDupire(strikes, mats, iv, S0, r, q)
+    market_np = np_eur.MarketData(r, dup_np)
+    asset_np = np_eur.EuropeanAsset(S0, q, T=T, dt=dt, n_paths=n_paths, seed=0)
+    opt_np = np_eur.MCEuropeanOption(asset_np, market_np, K, T, is_call=False)
+    price_np = opt_np()
+
+    print("Dupire TF:", price_tf)
+    print("Dupire NP:", price_np)
+    print("Close:", np.isclose(price_tf, price_np, rtol=5e-2))
+
+
+if __name__ == "__main__":
+    compare_dupire()

--- a/ml_greeks_pricers/volatility/np_discrete.py
+++ b/ml_greeks_pricers/volatility/np_discrete.py
@@ -1,0 +1,96 @@
+import numpy as np
+from dataclasses import dataclass
+
+from ml_greeks_pricers.pricers.np.black_utils import bs_price
+
+
+def _ensure_np(a, dtype):
+    return np.asarray(a, dtype=dtype)
+
+
+@dataclass
+class ImpliedVolSurface:
+    strikes: np.ndarray
+    maturities: np.ndarray
+    grid: np.ndarray
+    t0: np.ndarray | None = None
+    dtype: type = np.float64
+
+    def __init__(self, strikes, maturities, implied_vol_surface, t0=None, dtype=np.float64):
+        self.dtype = dtype
+        self.strikes = _ensure_np(strikes, dtype)
+        self.maturities = _ensure_np(maturities, dtype)
+        self.grid = _ensure_np(implied_vol_surface, dtype)
+        if t0 is None:
+            self.t0 = np.zeros_like(self.maturities)
+        else:
+            self.t0 = _ensure_np(t0, dtype)
+
+    @staticmethod
+    def bilinear(t, k, grid, strikes, maturities):
+        t = np.asarray(t, dtype=grid.dtype)
+        k = np.asarray(k, dtype=grid.dtype)
+        strikes = np.asarray(strikes, dtype=grid.dtype)
+        maturities = np.asarray(maturities, dtype=grid.dtype)
+        t_flat = t.ravel()
+        k_flat = k.ravel()
+        it = np.clip(np.searchsorted(maturities, t_flat, side="right") - 1, 0, len(maturities) - 2)
+        ik = np.clip(np.searchsorted(strikes, k_flat, side="right") - 1, 0, len(strikes) - 2)
+        t0 = maturities[it]; t1 = maturities[it + 1]
+        k0 = strikes[ik]; k1 = strikes[ik + 1]
+        wt = (t_flat - t0) / (t1 - t0)
+        wk = (k_flat - k0) / (k1 - k0)
+        g00 = grid[it, ik]
+        g10 = grid[it + 1, ik]
+        g01 = grid[it, ik + 1]
+        g11 = grid[it + 1, ik + 1]
+        result = (
+            (1 - wt) * (1 - wk) * g00
+            + wt * (1 - wk) * g10
+            + (1 - wt) * wk * g01
+            + wt * wk * g11
+        )
+        return result.reshape(t.shape)
+
+
+class DupireLocalVol(ImpliedVolSurface):
+    def __init__(self, strikes, maturities, implied_vol_surface, S0, r, q, t0=None, dtype=np.float64):
+        super().__init__(strikes, maturities, implied_vol_surface, t0, dtype)
+        self.S0 = float(S0)
+        self.r = float(r)
+        self.q = float(q)
+        self.surface = self._compute_surface()
+        self.grid = self.surface
+
+    def _compute_surface(self):
+        strikes = self.strikes
+        mats = self.maturities
+        iv = self.grid
+        S0 = self.S0
+        r = self.r
+        q = self.q
+        lv = np.empty((len(mats), len(strikes)), dtype=self.dtype)
+        for i, T in enumerate(mats):
+            for j, K in enumerate(strikes):
+                def price_fn(Tv, Kv):
+                    sigma = ImpliedVolSurface.bilinear(Tv, Kv, iv, strikes, mats)
+                    return bs_price(S0, Kv, Tv, 0.0, r, q, sigma, True)
+
+                eps_T = 1e-4 * max(float(T), 1.0)
+                eps_K = 1e-4 * max(float(K), 1.0)
+                C = price_fn(T, K)
+                C_T = (price_fn(T + eps_T, K) - price_fn(max(T - eps_T, 1e-8), K)) / (2 * eps_T)
+                C_K_plus = price_fn(T, K + eps_K)
+                C_K_minus = price_fn(T, max(K - eps_K, 1e-8))
+                C_K = (C_K_plus - C_K_minus) / (2 * eps_K)
+                C_KK = (C_K_plus - 2 * C + C_K_minus) / (eps_K ** 2)
+                num = C_T + (r - q) * K * C_K + q * C
+                den = 0.5 * K ** 2 * C_KK
+                if num > 0 and den > 0:
+                    lv[i, j] = np.sqrt(num / den)
+                else:
+                    lv[i, j] = np.nan
+        return lv
+
+    def __call__(self):
+        return self.surface


### PR DESCRIPTION
## Summary
- extend numpy MarketData and asset simulation to support Dupire local volatility surfaces
- implement `np_discrete` module with Dupire surface computation
- add comparison script for TensorFlow vs numpy Dupire pricing

## Testing
- `pytest -q`