### PR TITLE
Add plotting scripts for CSV surfaces

### DIFF
--- a/examples/plots/deltas/deltas.py
+++ b/examples/plots/deltas/deltas.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from ..utils import load_surface, plot_surface
+
+
+def main() -> None:
+    examples_dir = Path(__file__).resolve().parents[2]
+    outputs_dir = examples_dir / "outputs"
+    csv_files = outputs_dir.rglob("*_deltas.csv")
+    for csv_path in csv_files:
+        X, Y, Z = load_surface(csv_path)
+        name = f"{csv_path.parent.name}_{csv_path.stem}.png"
+        out_file = Path(__file__).with_name(name)
+        title = f"{csv_path.parent.name} {csv_path.stem.replace('_', ' ').title()}"
+        plot_surface(
+            X,
+            Y,
+            Z,
+            xlabel="Strike",
+            ylabel="Maturity",
+            zlabel="Delta",
+            title=title,
+            out_file=out_file,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plots/prices/prices.py
+++ b/examples/plots/prices/prices.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from ..utils import load_surface, plot_surface
+
+
+def main() -> None:
+    examples_dir = Path(__file__).resolve().parents[2]
+    outputs_dir = examples_dir / "outputs"
+    csv_files = outputs_dir.rglob("*_prices.csv")
+    for csv_path in csv_files:
+        X, Y, Z = load_surface(csv_path)
+        name = f"{csv_path.parent.name}_{csv_path.stem}.png"
+        out_file = Path(__file__).with_name(name)
+        title = f"{csv_path.parent.name} {csv_path.stem.replace('_', ' ').title()}"
+        plot_surface(
+            X,
+            Y,
+            Z,
+            xlabel="Strike",
+            ylabel="Maturity",
+            zlabel="Price",
+            title=title,
+            out_file=out_file,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plots/utils.py
+++ b/examples/plots/utils.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def load_surface(csv_path: Path):
+    """Return strike, maturity meshgrids and surface values from a CSV."""
+    df = pd.read_csv(csv_path, index_col=0)
+    strikes = df.columns.astype(float)
+    maturities = df.index.astype(float)
+    X, Y = np.meshgrid(strikes, maturities)
+    Z = df.values.astype(float)
+    return X, Y, Z
+
+
+def plot_surface(
+    X: np.ndarray,
+    Y: np.ndarray,
+    Z: np.ndarray,
+    xlabel: str,
+    ylabel: str,
+    zlabel: str,
+    title: str,
+    out_file: Path,
+):
+    """Generate and save a 3D surface plot."""
+    fig = plt.figure(figsize=(8, 5))
+    ax = fig.add_subplot(111, projection="3d")
+    surf = ax.plot_surface(X, Y, Z, cmap="viridis")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_zlabel(zlabel)
+    ax.set_title(title)
+    fig.colorbar(surf, shrink=0.5, aspect=5)
+    fig.tight_layout()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_file)
+    plt.close(fig)

--- a/examples/plots/vegas/vegas.py
+++ b/examples/plots/vegas/vegas.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from ..utils import load_surface, plot_surface
+
+
+def main() -> None:
+    examples_dir = Path(__file__).resolve().parents[2]
+    outputs_dir = examples_dir / "outputs"
+    csv_files = outputs_dir.rglob("*_vegas.csv")
+    for csv_path in csv_files:
+        X, Y, Z = load_surface(csv_path)
+        name = f"{csv_path.parent.name}_{csv_path.stem}.png"
+        out_file = Path(__file__).with_name(name)
+        title = f"{csv_path.parent.name} {csv_path.stem.replace('_', ' ').title()}"
+        plot_surface(
+            X,
+            Y,
+            Z,
+            xlabel="Strike",
+            ylabel="Maturity",
+            zlabel="Vega",
+            title=title,
+            out_file=out_file,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plots/volatility/volatility.py
+++ b/examples/plots/volatility/volatility.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from ..utils import load_surface, plot_surface
+
+
+def main() -> None:
+    examples_dir = Path(__file__).resolve().parents[2]
+    csv_path = examples_dir / "inputs" / "implied_vol_surface.csv"
+    X, Y, Z = load_surface(csv_path)
+    out_file = Path(__file__).with_name("implied_vol_surface.png")
+    plot_surface(
+        X,
+        Y,
+        Z,
+        xlabel="Strike",
+        ylabel="Maturity",
+        zlabel="Implied Volatility",
+        title="Implied Volatility Surface",
+        out_file=out_file,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utilities to load CSV surfaces and create 3D plots
- add scripts for volatility, prices, deltas and vegas

## Testing
- `pytest tests/test_vector_mc_european.py::test_vector_monte_carlo_prices -q`
- `pytest -q` *(interrupted due to time)*