### PR TITLE
Add slice plots for surface visualizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - Fix AmericanAsset.simulate failing under XLA when called from `tf.function` by using cached `n_steps` instead of `tf.get_static_value`.
+- Add 2D slice plots for surface visualizations in the examples.

--- a/examples/plots/deltas/deltas.py
+++ b/examples/plots/deltas/deltas.py
@@ -10,6 +10,43 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
+def plot_slices(
+    X: np.ndarray,
+    Y: np.ndarray,
+    Z: np.ndarray,
+    zlabel: str,
+    title: str,
+    out_file: Path,
+    strike_idx: int | None = None,
+    maturity_idx: int | None = None,
+):
+    """Generate and save 2D slice plots for fixed strike and maturity."""
+    strikes = X[0]
+    maturities = Y[:, 0]
+
+    if strike_idx is None:
+        strike_idx = len(strikes) // 2
+    if maturity_idx is None:
+        maturity_idx = len(maturities) // 2
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].plot(maturities, Z[:, strike_idx])
+    axes[0].set_xlabel("Maturity")
+    axes[0].set_ylabel(zlabel)
+    axes[0].set_title(f"Strike = {strikes[strike_idx]:.2f}")
+
+    axes[1].plot(strikes, Z[maturity_idx, :])
+    axes[1].set_xlabel("Strike")
+    axes[1].set_ylabel(zlabel)
+    axes[1].set_title(f"Maturity = {maturities[maturity_idx]:.2f}")
+
+    fig.suptitle(title)
+    fig.tight_layout()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_file)
+    plt.close(fig)
+
+
 def load_surface(csv_path: Path):
     """Return strike, maturity meshgrids and surface values from a CSV."""
     df = pd.read_csv(csv_path, index_col=0)
@@ -63,6 +100,15 @@ def main() -> None:
             zlabel="Delta",
             title=title,
             out_file=out_file,
+        )
+        slice_file = out_file.with_name(out_file.stem + "_slice.png")
+        plot_slices(
+            X,
+            Y,
+            Z,
+            zlabel="Delta",
+            title=title,
+            out_file=slice_file,
         )
 
 

--- a/examples/plots/prices/prices.py
+++ b/examples/plots/prices/prices.py
@@ -10,6 +10,43 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
+def plot_slices(
+    X: np.ndarray,
+    Y: np.ndarray,
+    Z: np.ndarray,
+    zlabel: str,
+    title: str,
+    out_file: Path,
+    strike_idx: int | None = None,
+    maturity_idx: int | None = None,
+):
+    """Generate and save 2D slice plots for fixed strike and maturity."""
+    strikes = X[0]
+    maturities = Y[:, 0]
+
+    if strike_idx is None:
+        strike_idx = len(strikes) // 2
+    if maturity_idx is None:
+        maturity_idx = len(maturities) // 2
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].plot(maturities, Z[:, strike_idx])
+    axes[0].set_xlabel("Maturity")
+    axes[0].set_ylabel(zlabel)
+    axes[0].set_title(f"Strike = {strikes[strike_idx]:.2f}")
+
+    axes[1].plot(strikes, Z[maturity_idx, :])
+    axes[1].set_xlabel("Strike")
+    axes[1].set_ylabel(zlabel)
+    axes[1].set_title(f"Maturity = {maturities[maturity_idx]:.2f}")
+
+    fig.suptitle(title)
+    fig.tight_layout()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_file)
+    plt.close(fig)
+
+
 def load_surface(csv_path: Path):
     """Return strike, maturity meshgrids and surface values from a CSV."""
     df = pd.read_csv(csv_path, index_col=0)
@@ -63,6 +100,15 @@ def main() -> None:
             zlabel="Price",
             title=title,
             out_file=out_file,
+        )
+        slice_file = out_file.with_name(out_file.stem + "_slice.png")
+        plot_slices(
+            X,
+            Y,
+            Z,
+            zlabel="Price",
+            title=title,
+            out_file=slice_file,
         )
 
 

--- a/examples/plots/vegas/vegas.py
+++ b/examples/plots/vegas/vegas.py
@@ -10,6 +10,43 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
+def plot_slices(
+    X: np.ndarray,
+    Y: np.ndarray,
+    Z: np.ndarray,
+    zlabel: str,
+    title: str,
+    out_file: Path,
+    strike_idx: int | None = None,
+    maturity_idx: int | None = None,
+):
+    """Generate and save 2D slice plots for fixed strike and maturity."""
+    strikes = X[0]
+    maturities = Y[:, 0]
+
+    if strike_idx is None:
+        strike_idx = len(strikes) // 2
+    if maturity_idx is None:
+        maturity_idx = len(maturities) // 2
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].plot(maturities, Z[:, strike_idx])
+    axes[0].set_xlabel("Maturity")
+    axes[0].set_ylabel(zlabel)
+    axes[0].set_title(f"Strike = {strikes[strike_idx]:.2f}")
+
+    axes[1].plot(strikes, Z[maturity_idx, :])
+    axes[1].set_xlabel("Strike")
+    axes[1].set_ylabel(zlabel)
+    axes[1].set_title(f"Maturity = {maturities[maturity_idx]:.2f}")
+
+    fig.suptitle(title)
+    fig.tight_layout()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_file)
+    plt.close(fig)
+
+
 def load_surface(csv_path: Path):
     """Return strike, maturity meshgrids and surface values from a CSV."""
     df = pd.read_csv(csv_path, index_col=0)
@@ -63,6 +100,15 @@ def main() -> None:
             zlabel="Vega",
             title=title,
             out_file=out_file,
+        )
+        slice_file = out_file.with_name(out_file.stem + "_slice.png")
+        plot_slices(
+            X,
+            Y,
+            Z,
+            zlabel="Vega",
+            title=title,
+            out_file=slice_file,
         )
 
 

--- a/examples/plots/volatility/volatility.py
+++ b/examples/plots/volatility/volatility.py
@@ -10,6 +10,43 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
+def plot_slices(
+    X: np.ndarray,
+    Y: np.ndarray,
+    Z: np.ndarray,
+    zlabel: str,
+    title: str,
+    out_file: Path,
+    strike_idx: int | None = None,
+    maturity_idx: int | None = None,
+):
+    """Generate and save 2D slice plots for fixed strike and maturity."""
+    strikes = X[0]
+    maturities = Y[:, 0]
+
+    if strike_idx is None:
+        strike_idx = len(strikes) // 2
+    if maturity_idx is None:
+        maturity_idx = len(maturities) // 2
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+    axes[0].plot(maturities, Z[:, strike_idx])
+    axes[0].set_xlabel("Maturity")
+    axes[0].set_ylabel(zlabel)
+    axes[0].set_title(f"Strike = {strikes[strike_idx]:.2f}")
+
+    axes[1].plot(strikes, Z[maturity_idx, :])
+    axes[1].set_xlabel("Strike")
+    axes[1].set_ylabel(zlabel)
+    axes[1].set_title(f"Maturity = {maturities[maturity_idx]:.2f}")
+
+    fig.suptitle(title)
+    fig.tight_layout()
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_file)
+    plt.close(fig)
+
+
 def load_surface(csv_path: Path):
     """Return strike, maturity meshgrids and surface values from a CSV."""
     df = pd.read_csv(csv_path, index_col=0)
@@ -59,6 +96,15 @@ def main() -> None:
         zlabel="Implied Volatility",
         title="Implied Volatility Surface",
         out_file=out_file,
+    )
+    slice_file = out_file.with_name(out_file.stem + "_slice.png")
+    plot_slices(
+        X,
+        Y,
+        Z,
+        zlabel="Implied Volatility",
+        title="Implied Volatility Surface",
+        out_file=slice_file,
     )
 
 


### PR DESCRIPTION
## Summary
- add 2D slice plotting capability alongside existing surface plots
- plot slices for prices, deltas, vegas and implied volatility
- document new feature in the changelog

## Testing
- `ruff check examples/plots/prices/prices.py examples/plots/deltas/deltas.py examples/plots/vegas/vegas.py examples/plots/volatility/volatility.py`
- `pytest -q` *(fails: RuntimeError in TensorFlow due to heavy computations)*