### PR TITLE
Fix path simulation when not using tf.scan

### DIFF
--- a/ml_greeks_pricers/pricers/tf/european.py
+++ b/ml_greeks_pricers/pricers/tf/european.py
@@ -296,13 +296,15 @@ class EuropeanAsset:
 
         if self.use_scan:
             path = tf.scan(step, (dW, times), initializer=S)
+            result = path[-1]
+            if save_path:
+                self.path = path
         else:
-            path = tf.foldl(step, (dW, times), initializer=S)
-        
-        if save_path == True:
-            self.path = path
-            
-        return path[-1]
+            result = tf.foldl(step, (dW, times), initializer=S)
+            if save_path:
+                self.path = result
+
+        return result
 
 class MCEuropeanOption:
     """Monte Carlo pricer for European options."""


### PR DESCRIPTION
## Summary
- correct asset path generation when `use_scan=False` so prices are not zero

## Testing
- `pytest -q` *(fails: Killed)*